### PR TITLE
Made option name parameter optional to allow grouping

### DIFF
--- a/admin/options-interface.php
+++ b/admin/options-interface.php
@@ -52,7 +52,11 @@ function optionsframework_fields() {
 			}
 
 			$output .= '<div id="' . esc_attr( $id ) .'" class="' . esc_attr( $class ) . '">'."\n";
-			$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
+			
+			if ( $value['name'] ) {
+				$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
+			}
+			
 			$output .= '<div class="option">' . "\n" . '<div class="controls">' . "\n";
 		 }
 		


### PR DESCRIPTION
I usually don't need to print the option title for all my options so this is just a rather simple change that I've used pretty much since I discover this library, it basically allows you to so something like this:

![Theme Options](http://s3.amazonaws.com/diigo/2564615_104343546_5972804?AWSAccessKeyId=0R7FMW7AXRVCYMAPTPR2&Expires=1327179494&Signature=5nXJ0p1pg9baJtqH0VWuCHVBkfI%3D)

Hopefully others can benefit from it as well, let me know what you think :)
