### PR TITLE
Typography size always resets

### DIFF
--- a/admin/options-interface.php
+++ b/admin/options-interface.php
@@ -211,7 +211,7 @@ function optionsframework_fields() {
 			$output .= '<select class="of-typography of-typography-size" name="' . esc_attr( $option_name . '[' . $value['id'] . '][size]' ) . '" id="' . esc_attr( $value['id'] . '_size' ) . '">';
 			for ($i = 9; $i < 71; $i++) {
 				$size = $i . 'px';
-				$output .= '<option value="' . esc_attr( $size ) . '" ' . selected( $typography_stored['size'], $size, false ) . '>' . esc_html( $size ) . '</option>';
+				$output .= '<option value="' . esc_attr( $size ) . '" ' . selected( $typography_stored['size'], $i, false ) . '>' . esc_html( $size ) . '</option>';
 			}
 			$output .= '</select>';
 


### PR DESCRIPTION
selected function testing on size string instead of size integer.  Looks like it's also this way on the plugin side.  Since the of_sanitize_font_size filter returns just an integer, but when looping over the sizes for populating the select field on options-interface the actual field value is used to test if it should be selected instead of just the integer.  

Side note might want to change the documentation to show that font sizes are returned without the unit anymore. This threw me off when I updated from .8 to 1.
