### PR TITLE
custom style code similar to custom script code

### DIFF
--- a/inc/options-framework.php
+++ b/inc/options-framework.php
@@ -52,7 +52,7 @@ function optionsframework_load_sanitization() {
 	require_once dirname( __FILE__ ) . '/options-sanitize.php';
 }
 
-/* 
+/*
  * Creates the settings in the database by looping through the array
  * we supplied in options.php.  This is a neat way to do it since
  * we won't have to save settings for headers, descriptions, or arguments.
@@ -67,7 +67,7 @@ function optionsframework_init() {
 	// Include the required files
 	require_once dirname( __FILE__ ) . '/options-interface.php';
 	require_once dirname( __FILE__ ) . '/options-medialibrary-uploader.php';
-	
+
 	// Loads the options array from the theme
 	if ( $optionsfile = locate_template( array('options.php') ) ) {
 		require_once($optionsfile);
@@ -75,12 +75,12 @@ function optionsframework_init() {
 	else if (file_exists( dirname( __FILE__ ) . '/options.php' ) ) {
 		require_once dirname( __FILE__ ) . '/options.php';
 	}
-	
+
 	$optionsframework_settings = get_option('optionsframework' );
-	
+
 	// Updates the unique option id in the database if it has changed
 	optionsframework_option_name();
-	
+
 	// Gets the unique id, returning a default if it isn't defined
 	if ( isset($optionsframework_settings['id']) ) {
 		$option_name = $optionsframework_settings['id'];
@@ -88,15 +88,15 @@ function optionsframework_init() {
 	else {
 		$option_name = 'optionsframework';
 	}
-	
+
 	// If the option has no saved data, load the defaults
 	if ( ! get_option($option_name) ) {
 		optionsframework_setdefaults();
 	}
-	
+
 	// Registers the settings fields and callback
 	register_setting( 'optionsframework', $option_name, 'optionsframework_validate' );
-	
+
 	// Change the capability required to save the 'optionsframework' options group.
 	add_filter( 'option_page_capability_optionsframework', 'optionsframework_page_capability' );
 }
@@ -113,7 +113,7 @@ function optionsframework_page_capability( $capability ) {
 	return 'edit_theme_options';
 }
 
-/* 
+/*
  * Adds default options to the database if they aren't already present.
  * May update this later to load only on plugin activation, or theme
  * activation since most people won't be editing the options.php
@@ -124,20 +124,20 @@ function optionsframework_page_capability( $capability ) {
  */
 
 function optionsframework_setdefaults() {
-	
+
 	$optionsframework_settings = get_option('optionsframework');
 
 	// Gets the unique option id
 	$option_name = $optionsframework_settings['id'];
-	
-	/* 
+
+	/*
 	 * Each theme will hopefully have a unique id, and all of its options saved
 	 * as a separate option set.  We need to track all of these option sets so
 	 * it can be easily deleted if someone wishes to remove the plugin and
-	 * its associated data.  No need to clutter the database.  
+	 * its associated data.  No need to clutter the database.
 	 *
 	 */
-	
+
 	if ( isset($optionsframework_settings['knownoptions']) ) {
 		$knownoptions =  $optionsframework_settings['knownoptions'];
 		if ( !in_array($option_name, $knownoptions) ) {
@@ -150,13 +150,13 @@ function optionsframework_setdefaults() {
 		$optionsframework_settings['knownoptions'] = $newoptionname;
 		update_option('optionsframework', $optionsframework_settings);
 	}
-	
+
 	// Gets the default options data from the array in options.php
 	$options = optionsframework_options();
-	
+
 	// If the options haven't been added to the database yet, they are added now
 	$values = of_get_default_values();
-	
+
 	if ( isset($values) ) {
 		add_option( $option_name, $values ); // Add option with default settings
 	}
@@ -168,12 +168,12 @@ if ( !function_exists( 'optionsframework_add_page' ) ) {
 
 	function optionsframework_add_page() {
 		$of_page = add_theme_page(__('Theme Options', 'options_framework_theme'), __('Theme Options', 'options_framework_theme'), 'edit_theme_options', 'options-framework','optionsframework_page');
-		
+
 		// Load the required CSS and javscript
 		add_action('admin_enqueue_scripts', 'optionsframework_load_scripts');
 		add_action( 'admin_print_styles-' . $of_page, 'optionsframework_load_styles' );
 	}
-	
+
 }
 
 /* Loads the CSS */
@@ -181,7 +181,10 @@ if ( !function_exists( 'optionsframework_add_page' ) ) {
 function optionsframework_load_styles() {
 	wp_enqueue_style('optionsframework', OPTIONS_FRAMEWORK_DIRECTORY.'css/optionsframework.css');
 	wp_enqueue_style('color-picker', OPTIONS_FRAMEWORK_DIRECTORY.'css/colorpicker.css');
-}	
+
+	// Inline scripts from options-interface.php
+	add_action('admin_head', 'of_admin_head_styles');
+}
 
 /* Loads the javascript */
 
@@ -189,23 +192,29 @@ function optionsframework_load_scripts($hook) {
 
 	if ( 'appearance_page_options-framework' != $hook )
         return;
-	
+
 	// Enqueued scripts
 	wp_enqueue_script('jquery-ui-core');
 	wp_enqueue_script('color-picker', OPTIONS_FRAMEWORK_DIRECTORY.'js/colorpicker.js', array('jquery'));
 	wp_enqueue_script('options-custom', OPTIONS_FRAMEWORK_DIRECTORY.'js/options-custom.js', array('jquery'));
-	
+
 	// Inline scripts from options-interface.php
-	add_action('admin_head', 'of_admin_head');
+	add_action('admin_head', 'of_admin_head_scripts');
 }
 
-function of_admin_head() {
+function of_admin_head_styles() {
+
+	// Hook to add custom scripts
+	do_action( 'optionsframework_custom_styles' );
+}
+
+function of_admin_head_scripts() {
 
 	// Hook to add custom scripts
 	do_action( 'optionsframework_custom_scripts' );
 }
 
-/* 
+/*
  * Builds out the options panel.
  *
  * If we were using the Settings API as it was likely intended we would use
@@ -249,7 +258,7 @@ if ( !function_exists( 'optionsframework_page' ) ) {
 	}
 }
 
-/** 
+/**
  * Validate Options.
  *
  * This runs after the submit/reset button has been clicked and
@@ -267,7 +276,7 @@ function optionsframework_validate( $input ) {
 	 * button, the options defined in the theme's options.php
 	 * file will be added to the option for the active theme.
 	 */
-	 
+
 	if ( isset( $_POST['reset'] ) ) {
 		add_settings_error( 'options-framework', 'restore_defaults', __( 'Default options restored.', 'options_framework_theme' ), 'updated fade' );
 		return of_get_default_values();
@@ -276,7 +285,7 @@ function optionsframework_validate( $input ) {
 	/*
 	 * Udpdate Settings.
 	 */
-	 
+
 	if ( isset( $_POST['update'] ) ) {
 		$clean = array();
 		$options = optionsframework_options();
@@ -317,7 +326,7 @@ function optionsframework_validate( $input ) {
 	/*
 	 * Request Not Recognized.
 	 */
-	
+
 	return of_get_default_values();
 }
 
@@ -334,7 +343,7 @@ function optionsframework_validate( $input ) {
  *
  * @access    private
  */
- 
+
 function of_get_default_values() {
 	$output = array();
 	$config = optionsframework_options();
@@ -380,7 +389,7 @@ if ( ! function_exists( 'of_get_option' ) ) {
 	 * If no value has been saved, it returns $default.
 	 * Needed because options are saved as serialized strings.
 	 */
-	 
+
 	function of_get_option( $name, $default = false ) {
 		$config = get_option( 'optionsframework' );
 


### PR DESCRIPTION
Besisdes the handy option to add custom script code to the theme options I also needed to add custom style matching some of the js code I've added, so I added support for both things in the same way as you did with scripts
