### PR TITLE
replacing old WP option with new wp_get_theme()

### DIFF
--- a/options.php
+++ b/options.php
@@ -8,7 +8,8 @@
 function optionsframework_option_name() {
 
 	// This gets the theme name from the stylesheet
-	$themename = get_option( 'stylesheet' );
+	//$themename = get_option( 'stylesheet' );
+	$themename = wp_get_theme();
 	$themename = preg_replace("/\W/", "_", strtolower($themename) );
 
 	$optionsframework_settings = get_option( 'optionsframework' );


### PR DESCRIPTION
instead of using get_option('stylesheet') we can use new WP 3.4 function wp_get_theme() 

INFO: http://codex.wordpress.org/Function_Reference/wp_get_theme
