### PR TITLE
color hex values always save with # prepended

### DIFF
--- a/inc/options-sanitize.php
+++ b/inc/options-sanitize.php
@@ -283,6 +283,9 @@ function of_recognized_background_attachment() {
 
 function of_sanitize_hex( $hex, $default = '' ) {
 	if ( of_validate_hex( $hex ) ) {
+		if ( 0 !== strpos( $hex, '#' ) ) {
+			$hex = '#' . $hex;
+		}
 		return $hex;
 	}
 	return $default;


### PR DESCRIPTION
Reasons to include #:

It makes sense to attach # to hex color values because that's what they begin with.
The developer has more peace of mind knowing that # will always be there instead of it might or might not being there.

Thank you very much for the awesome framework!
