### PR TITLE
simplify hex validation, color always saves with # prepended

### DIFF
--- a/inc/options-sanitize.php
+++ b/inc/options-sanitize.php
@@ -283,6 +283,7 @@ function of_recognized_background_attachment() {
 
 function of_sanitize_hex( $hex, $default = '' ) {
 	if ( of_validate_hex( $hex ) ) {
+		$hex = '#' . strtolower( ltrim( trim( $hex ), '#' ) );
 		return $hex;
 	}
 	return $default;
@@ -358,19 +359,8 @@ function of_recognized_font_styles() {
  */
 
 function of_validate_hex( $hex ) {
-	$hex = trim( $hex );
-	/* Strip recognized prefixes. */
-	if ( 0 === strpos( $hex, '#' ) ) {
-		$hex = substr( $hex, 1 );
-	}
-	elseif ( 0 === strpos( $hex, '%23' ) ) {
-		$hex = substr( $hex, 3 );
-	}
-	/* Regex match. */
-	if ( 0 === preg_match( '/^[0-9a-fA-F]{6}$/', $hex ) ) {
-		return false;
-	}
-	else {
+	if ( preg_match( '/^#?([a-f0-9]{3}){1,2}$/i', trim( $hex ) ) ) {
 		return true;
 	}
+	return false;
 }


### PR DESCRIPTION
Sorry for flooding the pull requests, I'm new to git and terminal.

I plugged in the snippet you provided from the twenty-eleven theme
- always lowercases color and saves with #
- allows for 3 char hex values also instead of only 6
- simple preg match for valid hex (without the %23 check, which I don't think twenty-eleven checks for anyways)
