### PR TITLE
Adding an html view to theme option types

### DIFF
--- a/inc/options-interface.php
+++ b/inc/options-interface.php
@@ -364,6 +364,30 @@ function optionsframework_fields() {
 			}
 			$output .= '</div>' . "\n";
 			break;
+	
+		// View - using custom html
+		case "view":
+			$id = '';
+			$class = 'section';
+			if ( isset( $value['id'] ) ) {
+				$id = 'id="' . esc_attr( $value['id'] ) . '" ';
+			}
+			if ( isset( $value['type'] ) ) {
+				$class .= ' section-' . $value['type'];
+			}
+			if ( isset( $value['class'] ) ) {
+				$class .= ' ' . $value['class'];
+			}
+
+			$output .= '<div ' . $id . 'class="' . esc_attr( $class ) . '">' . "\n";
+			if ( isset($value['name']) ) {
+				$output .= '<h4 class="heading">' . esc_html( $value['name'] ) . '</h4>' . "\n";
+			}
+			if ( $value['html'] ) {
+				$output .= $value['html'];
+			}
+			$output .= '</div>' . "\n";
+			break;
 
 		// Heading for Navigation
 		case "heading":


### PR DESCRIPTION
Allow one to parse custom html to theme options and avoid sanitation. Added when I had to display a table of dynamically generated data in the theme options section.
