### PR TITLE
Update options-framework.php

### DIFF
--- a/inc/options-framework.php
+++ b/inc/options-framework.php
@@ -62,10 +62,7 @@ function optionsframework_init() {
 	
 	// Loads the options array from the theme
 	if ( $optionsfile = locate_template( array('options.php') ) ) {
-		require_once($optionsfile);
-	}
-	else if ( file_exists( dirname( __FILE__ ) . '/options.php' ) ) {
-		require_once dirname( __FILE__ ) . '/options.php';
+		get_template_part('options');
 	}
 	
 	// Load settings


### PR DESCRIPTION
I am using theme-check plugin to check for errors in a template I'm developing using your faboulous Framework and theme check says this:

 <strong>inc/options-framework.php The theme appears to use include or require. If these are being used to include separate sections of a template from independent files, then get_template_part() should be used instead.</strong>

This is the reason why I'm asking for a file change.
