### PR TITLE
Avoid error when options.php does not exist.

### DIFF
--- a/inc/options-framework.php
+++ b/inc/options-framework.php
@@ -454,10 +454,18 @@ function &_optionsframework_options() {
 			$maybe_options = require_once $optionsfile;
 			if ( is_array($maybe_options) ) {
 				$options = $maybe_options;
-			} else if ( function_exists( 'optionsframework_options' ) ) {
-				$options = optionsframework_options();
 			}
 		}
+
+        if (!is_array($options)) {
+            if ( function_exists( 'optionsframework_options' ) ) {
+                $options = optionsframework_options();
+            }
+            else
+            {
+                $options = array();
+            }
+        }
 
 		// Allow setting/manipulating options via filters
 		$options = apply_filters('of_options', $options);


### PR DESCRIPTION
More safe way to load config to avoid a warning in options-interface.php [line 12] in case options.php does not exist.

Please, can you add a tag for v1.6 after this merge (if you want to merge of course) :+1: 
