### PR TITLE
Editor Default Settings Override

### DIFF
--- a/inc/options-interface.php
+++ b/inc/options-interface.php
@@ -335,7 +335,7 @@ function optionsframework_fields() {
 
 		// Editor
 		case 'editor':
-			$output .= '<div class="explain">' . wp_kses( $explain_value, $allowedtags) . '</div>'."\n";
+			$output .= '<div class="explain">' . wp_kses( $explain_value, $allowedtags ) . '</div>'."\n";
 			echo $output;
 			$textarea_name = esc_attr( $option_name . '[' . $value['id'] . ']' );
 			$default_editor_settings = array(
@@ -346,7 +346,7 @@ function optionsframework_fields() {
 			if ( isset( $value['settings'] ) ) {
 				$editor_settings = $value['settings'];
 			}
-			$editor_settings = array_merge($default_editor_settings, $editor_settings);
+			$editor_settings = array_merge( $default_editor_settings, $editor_settings );
 			$editor_settings['textarea_name'] = $textarea_name;
 			wp_editor( $val, $value['id'], $editor_settings );
 			$output = '';


### PR DESCRIPTION
I ran into an issue where I could not override the 'media_buttons' or 'tinymce' attributes of the settings array that is passed to wp_editor.  This is because the 'default_editor_settings' array was being merged into the settings override array.  By reversing this, I am now able to modify all settings that are passed into wp_editor.  I made sure to set the 'textarea_name' parameter after the merge so that it does not change.  Anyways, thanks for the great work.  I have used optionsframework on several projects and it has saved me a great deal of time!
