### PR TITLE
Add wide option for text input

### DIFF
--- a/inc/css/optionsframework.css
+++ b/inc/css/optionsframework.css
@@ -141,7 +141,9 @@
 #optionsframework .mini .explain {
 	max-width:74%;
 }
-
+#optionsframework .wide .controls input {
+	width: 100%;
+}
 /* Editor */
 
 #optionsframework .section-editor .explain {


### PR DESCRIPTION
Since default 100% width would cause radio button issues, a wide option give the ability for the text input field to match width to upload, dropdown etc.
