### PR TITLE
Update class-options-framework-admin.php

### DIFF
--- a/inc/includes/class-options-framework-admin.php
+++ b/inc/includes/class-options-framework-admin.php
@@ -31,7 +31,7 @@ class Options_Framework_Admin {
     	if ( $options ) {
 
 			// Add the options page and menu item.
-			add_action( 'admin_menu', array( $this, 'add_options_page' ) );
+			add_action( 'admin_menu', array( $this, 'add_themeoptions_page' ) );
 
 			// Add the required scripts and styles
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_styles' ) );
@@ -96,7 +96,7 @@ class Options_Framework_Admin {
      *
      * @since 1.7.0
      */
-	function add_options_page() {
+	function add_themeoptions_page() {
 
 		$menu = $this->menu_settings();
 		$this->options_screen = add_theme_page( $menu['page_title'], $menu['menu_title'], $menu['capability'], $menu['menu_slug'], array( $this, 'options_page' ) );


### PR DESCRIPTION
rename add_option_page(), function name conflicts with Theme Check (http://wordpress.org/plugins/theme-check/)
