### PR TITLE
WordPress 4.4 style fix

### DIFF
--- a/inc/css/optionsframework.css
+++ b/inc/css/optionsframework.css
@@ -8,6 +8,10 @@
 	cursor: default;
 	background-color: #f1f1f1;
 	border-bottom: 1px solid #ddd;
+	font-size: 14px;
+    	padding: 8px 12px;
+    	margin: 0;
+    	line-height: 1.4;
 }
 #optionsframework p {
 	margin-bottom:0;


### PR DESCRIPTION
Something changed with headings in 4.4 and style of h3 titles under tabs is messed up.

This fixes it by adding to #optionsframework h3 the styles WordPress used to add to .metabox-holder h3.
